### PR TITLE
Stop pass the "true" value of options to the CLI

### DIFF
--- a/src/converter.js
+++ b/src/converter.js
@@ -17,7 +17,10 @@ parentPort.once('message', (value) => {
     /* Add flag params to conversion command */
     Object.keys(process.env).forEach(key => {
         if (nonFlagParams.indexOf(key) > -1) return;
-        command += ` --${key}="${process.env[key]}"`;
+        if (process.env[key] === "true")
+            command += ` --${key}`;
+        else
+            command += ` --${key}="${process.env[key]}"`;
     });
     
     if (params.silent !== 'true') console.log(`Converting ${inputPath}...`);


### PR DESCRIPTION
The calibre's ebook-converter actually does not accept value in some options. In the CLI context, the presence of the option already means that it is "true"

Fix #3