### PR TITLE
Remove require.main.path reliance

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,9 +32,6 @@ function convert (data) {
     }
 
     return new Promise((resolve, reject) => {
-        data.input = path.resolve(require.main.path, data.input);
-        data.output = path.resolve(require.main.path, data.output);
-
         const worker = new Worker(path.join(__dirname, './src/converter.js'), { env: { ...data } });
         const channel = new MessageChannel();
 


### PR DESCRIPTION
`require.main` is `undefined` if the `node-ebook-converter` consumer is using `esm`, so this PR removes the lines of code relying on it. The consumer should pass in the whole path without concern about the entry module.